### PR TITLE
Adjust highlights and add tests

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,11 +1,25 @@
-(full_ident
-  (identifier) @variable)
+(package
+  (full_ident
+    (identifier) @module))
 
-(full_ident
-  (identifier)
-  (identifier) @variable.member)
+(extend
+  (full_ident
+    (identifier) @type))
+
+(constant
+  (full_ident
+    (identifier) @constant))
 
 (field
+  (identifier) @property)
+
+(map_field
+  (identifier) @property)
+
+(oneof
+  (identifier) @type)
+
+(oneof_field
   (identifier) @property)
 
 (field_option
@@ -18,23 +32,26 @@
   (identifier) @property)
 
 [
-  "extend"
-  "extensions"
-  "oneof"
   "option"
-  "reserved"
   "syntax"
   "edition"
+] @keyword.directive
+
+[
+  "reserved"
   "to"
   "max"
 ] @keyword
 
 [
   "enum"
+  "extend"
+  "extensions"
   "group"
-  "service"
   "message"
   "map"
+  "oneof"
+  "service"
 ] @keyword.type
 
 "rpc" @keyword.function
@@ -60,22 +77,28 @@
 [
   (key_type)
   (type)
+] @type.builtin
+
+[
   (message_name)
   (enum_name)
   (service_name)
-  (rpc_name)
   (message_or_enum_type)
 ] @type
+
+(rpc_name) @function.method
 
 (enum_field
   (identifier) @constant)
 
 (string) @string
 
+(import path: (string) @string.special.path)
+
 [
   "\"proto3\""
   "\"proto2\""
-] @string.special
+] @string.special.symbol
 
 (escape_sequence) @string.escape
 
@@ -88,10 +111,11 @@
   (false)
 ] @boolean
 
-(comment) @comment @spell
+(comment) @spell
+(comment) @comment
 
 ((comment) @comment.documentation
-  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+  (#match? @comment.documentation "^/\\*\\*[^\\*].*\\*/$"))
 
 [
   "("

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -93,7 +93,8 @@
 
 (string) @string
 
-(import path: (string) @string.special.path)
+(import
+  path: (string) @string.special.path)
 
 [
   "\"proto3\""
@@ -112,6 +113,7 @@
 ] @boolean
 
 (comment) @spell
+
 (comment) @comment
 
 [

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -114,9 +114,6 @@
 (comment) @spell
 (comment) @comment
 
-((comment) @comment.documentation
-  (#match? @comment.documentation "^/\\*\\*[^\\*].*\\*/$"))
-
 [
   "("
   ")"

--- a/test/highlight/highlights.proto
+++ b/test/highlight/highlights.proto
@@ -10,10 +10,10 @@ import "google/protobuf/any.proto";
 //^ keyword.import
 //     ^ string.special.path
 
-/** A doc comment */
-//^ comment.documentation
+/** A block comment */
+//^ comment
 
-// A regular comment
+// A line comment
 //^ comment
 
 enum Status {

--- a/test/highlight/highlights.proto
+++ b/test/highlight/highlights.proto
@@ -1,0 +1,143 @@
+syntax = "proto3";
+//^ keyword.directive
+//       ^ string.special.symbol
+
+package foo.bar;
+//      ^ module
+//          ^ module
+
+import "google/protobuf/any.proto";
+//^ keyword.import
+//     ^ string.special.path
+
+/** A doc comment */
+//^ comment.documentation
+
+// A regular comment
+//^ comment
+
+enum Status {
+//^ keyword.type
+//   ^ type
+  STATUS_UNKNOWN = 0;
+//^ constant
+  reserved 1 to max;
+//^ keyword
+//           ^ keyword
+//              ^ keyword
+}
+
+message TypeTest {
+//^ keyword.type
+//      ^ type
+  int32 count = 1;
+//^ type.builtin
+  MyMessage msg = 2;
+//^ type
+}
+
+extend Foo {
+//     ^ type
+}
+
+option my_option = MY_ENUM_VALUE;
+//                 ^ constant
+
+service Greeter {
+//^ keyword.type
+//      ^ type
+  rpc SayHello(HelloRequest) returns (HelloResponse);
+//^ keyword.function
+//    ^ function.method
+//                           ^ keyword.return
+}
+
+// map_field: the field name identifier should be @property
+message MapFieldTest {
+  map<string, int32> labels = 1;
+//                   ^ property
+}
+
+// oneof: the container name should be @type,
+// and each oneof_field name should be @property
+message OneofTest {
+  oneof contact {
+//      ^ type
+    string name = 1;
+//         ^ property
+    SubMessage sub = 9;
+//             ^ property
+  }
+}
+
+// keyword.modifier: repeated, optional, etc.
+message MundaneTest {
+  repeated string tags = 1;
+//^ keyword.modifier
+
+  bool flag = 2;
+//     ^ property
+
+  float ratio = 3;
+//^ type.builtin
+}
+
+// operator: =, -, +
+enum Polarity {
+  POSITIVE = 1;
+//         ^ operator
+//           ^ number
+  NEGATIVE = -1;
+//           ^ operator
+//            ^ number
+}
+
+// string.escape, punctuation.bracket, punctuation.delimiter
+message EscapeTest {
+  string val = 1;
+//           ^ operator
+//             ^ number
+//^ type.builtin
+//       ^ property
+}
+
+// boolean in field options; enum_value_option property
+enum FlagEnum {
+  FLAG_A = 0 [deprecated = false];
+//             ^ property
+//                          ^ boolean
+}
+
+// block_lit property
+option (my.opt) = {key: "val"};
+//                 ^ property
+
+// boolean in field options
+message BoolTest {
+  string name = 1 [deprecated = true];
+//                              ^ boolean
+}
+
+// number.float
+option (my.threshold) = 3.14;
+//                      ^ number.float
+
+option optimize_for = SPEED;
+//^ keyword.directive
+
+// string and string.escape
+option java_package = "com\nexample";
+//                    ^ string
+//                        ^ string.escape
+
+// punctuation.bracket and punctuation.delimiter
+message PunctuationTest {
+//                      ^ punctuation.bracket
+  map<string, int32> labels = 1;
+//   ^ punctuation.bracket
+//          ^ punctuation.delimiter
+//                 ^ punctuation.bracket
+//                          ^ operator
+//                            ^ number
+//                             ^ punctuation.delimiter
+}


### PR DESCRIPTION
This more fully aligns the highlights with the [capture groups defined in nvim-treesitter][1], and also adds a more thorough test suite for highlights. Hopefully the changes are fairly self-explanatory.

[1]: https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#highlights