### PR TITLE
Add option variables/members

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -31,6 +31,16 @@
 (block_lit
   (identifier) @property)
 
+; Extension option names, e.g. option (foo.bar) = ...
+(option
+  (full_ident
+    (identifier) @variable))
+
+(option
+  (full_ident
+    (identifier)
+    (identifier) @variable.member))
+
 [
   "option"
   "syntax"

--- a/test/highlight/highlights.proto
+++ b/test/highlight/highlights.proto
@@ -108,8 +108,10 @@ enum FlagEnum {
 //                          ^ boolean
 }
 
-// block_lit property
+// block_lit property; extension option name variable/variable.member
 option (my.opt) = {key: "val"};
+//      ^ variable
+//         ^ variable.member
 //                 ^ property
 
 // boolean in field options
@@ -120,6 +122,8 @@ message BoolTest {
 
 // number.float
 option (my.threshold) = 3.14;
+//      ^ variable
+//         ^ variable.member
 //                      ^ number.float
 
 option optimize_for = SPEED;


### PR DESCRIPTION
In syncing this upstream, I noticed we were missing these; this adds those back.

Ref: nvim-treesitter/nvim-treesitter#8574