### PR TITLE
Remove dead grammar rule; fix highlight/indent/fold query gaps

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -313,11 +313,6 @@ module.exports = grammar({
       )),
     ),
 
-    field_names: $ => seq(
-      $._identifier_or_string,
-      repeat(seq(',', $._identifier_or_string)),
-    ),
-
     reserved_field_names: $ => seq(
       $.reserved_identifier,
       repeat(seq(',', $.reserved_identifier)),
@@ -451,7 +446,6 @@ module.exports = grammar({
         ),
       ),
     ),
-    _identifier_or_string: $ => choice($.identifier, $.string),
 
     // fullIdent = ident { "." ident }
     full_ident: $ => seq(

--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -1,5 +1,7 @@
 [
   (enum)
+  (extend)
+  (group)
   (message)
   (service)
   (oneof)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -32,14 +32,28 @@
   (identifier) @property)
 
 ; Extension option names, e.g. option (foo.bar) = ...
+; Also matches field/enum-value options, e.g. [(foo.bar) = ...]
+[
+  (option (full_ident (identifier) @variable))
+  (field_option (full_ident (identifier) @variable))
+  (enum_value_option (full_ident (identifier) @variable))
+]
+
+[
+  (option (full_ident (identifier) (identifier) @variable.member))
+  (field_option (full_ident (identifier) (identifier) @variable.member))
+  (enum_value_option (full_ident (identifier) (identifier) @variable.member))
+]
+
+; Bare option names, e.g. option java_package = ...
+; Also matches the trailing segments of a parenthesized name,
+; e.g. option (foo.bar).baz = ...
 (option
-  (full_ident
-    (identifier) @variable))
+  (identifier) @variable)
 
 (option
-  (full_ident
-    (identifier)
-    (identifier) @variable.member))
+  (identifier)
+  (identifier) @variable.member)
 
 [
   "option"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -48,12 +48,10 @@
 ; Bare option names, e.g. option java_package = ...
 ; Also matches the trailing segments of a parenthesized name,
 ; e.g. option (foo.bar).baz = ...
+; Matches the @property treatment of bare field_option/enum_value_option
+; names below, since these all name a field on a proto *Options message.
 (option
-  (identifier) @variable)
-
-(option
-  (identifier)
-  (identifier) @variable.member)
+  (identifier) @property)
 
 [
   "option"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -34,15 +34,30 @@
 ; Extension option names, e.g. option (foo.bar) = ...
 ; Also matches field/enum-value options, e.g. [(foo.bar) = ...]
 [
-  (option (full_ident (identifier) @variable))
-  (field_option (full_ident (identifier) @variable))
-  (enum_value_option (full_ident (identifier) @variable))
+  (option
+    (full_ident
+      (identifier) @variable))
+  (field_option
+    (full_ident
+      (identifier) @variable))
+  (enum_value_option
+    (full_ident
+      (identifier) @variable))
 ]
 
 [
-  (option (full_ident (identifier) (identifier) @variable.member))
-  (field_option (full_ident (identifier) (identifier) @variable.member))
-  (enum_value_option (full_ident (identifier) (identifier) @variable.member))
+  (option
+    (full_ident
+      (identifier)
+      (identifier) @variable.member))
+  (field_option
+    (full_ident
+      (identifier)
+      (identifier) @variable.member))
+  (enum_value_option
+    (full_ident
+      (identifier)
+      (identifier) @variable.member))
 ]
 
 ; Bare option names, e.g. option java_package = ...

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -8,7 +8,8 @@
 ; rpc's body is optional (it can end in ";" instead of "{ }"), so anchor on
 ; the brace itself rather than the whole node to avoid indenting past a
 ; semicolon-terminated rpc.
-(rpc "{" @indent.begin)
+(rpc
+  "{" @indent.begin)
 
 "}" @indent.end @indent.branch
 

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,7 +1,14 @@
 [
   (message_body)
   (enum_body)
+  (oneof)
+  (service)
 ] @indent.begin
+
+; rpc's body is optional (it can end in ";" instead of "{ }"), so anchor on
+; the brace itself rather than the whole node to avoid indenting past a
+; semicolon-terminated rpc.
+(rpc "{" @indent.begin)
 
 "}" @indent.end @indent.branch
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1125,31 +1125,6 @@
         }
       ]
     },
-    "field_names": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_identifier_or_string"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_identifier_or_string"
-              }
-            ]
-          }
-        }
-      ]
-    },
     "reserved_field_names": {
       "type": "SEQ",
       "members": [
@@ -1767,19 +1742,6 @@
           }
         ]
       }
-    },
-    "_identifier_or_string": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string"
-        }
-      ]
     },
     "full_ident": {
       "type": "SEQ",

--- a/test/highlight/highlights.proto
+++ b/test/highlight/highlights.proto
@@ -106,6 +106,12 @@ enum FlagEnum {
   FLAG_A = 0 [deprecated = false];
 //             ^ property
 //                          ^ boolean
+
+  // enum_value_option: parenthesized extension name should be
+  // @variable / @variable.member, same as field_option and top-level option
+  FLAG_B = 1 [(validate.rules) = true];
+//             ^ variable
+//                      ^ variable.member
 }
 
 // block_lit property; extension option name variable/variable.member
@@ -128,11 +134,24 @@ option (my.threshold) = 3.14;
 
 option optimize_for = SPEED;
 //^ keyword.directive
+//     ^ variable
 
 // string and string.escape
 option java_package = "com\nexample";
+//     ^ variable
 //                    ^ string
 //                        ^ string.escape
+
+// field_option / enum_value_option: parenthesized extension names should be
+// @variable / @variable.member, same as top-level option; trailing path
+// segments after the parens stay @property
+message ParenFieldOptionTest {
+  string id = 1 [(validate.rules).string.min_len = 1];
+//                ^ variable
+//                         ^ variable.member
+//                                ^ property
+//                                       ^ property
+}
 
 // punctuation.bracket and punctuation.delimiter
 message PunctuationTest {

--- a/test/highlight/highlights.proto
+++ b/test/highlight/highlights.proto
@@ -134,11 +134,11 @@ option (my.threshold) = 3.14;
 
 option optimize_for = SPEED;
 //^ keyword.directive
-//     ^ variable
+//     ^ property
 
 // string and string.escape
 option java_package = "com\nexample";
-//     ^ variable
+//     ^ property
 //                    ^ string
 //                        ^ string.escape
 


### PR DESCRIPTION
## Summary
- Remove `field_names`/`_identifier_or_string`, two rules left behind by an earlier refactor of `reserved` that were never referenced anywhere (confirmed the compiled parser is byte-identical with or without them).
- `highlights.scm`: bare option names (`option java_package = ...`) and parenthesized extension names on `field_option`/`enum_value_option` (e.g. `[(validate.rules).string.min_len = 1]`) had no highlight capture at all; both are common in real-world `.proto` files (including this repo's own `a_bit_of_everything` corpus fixture).
- `indents.scm`: `oneof`, `service`, and brace-bodied `rpc` blocks never triggered `@indent.begin`, since (unlike `message`/`enum`/`extend`/`group`) they don't route through a shared body node.
- `folds.scm`: `extend`/`group` have the same brace-delimited shape as `message`/`enum`/`service`/`oneof`/`rpc` but were left out of the foldable list.

## Test plan
- [x] `tree-sitter test` passes: 27/27 corpus tests, 67/67 highlight assertions (new assertions added in `test/highlight/highlights.proto` cover both `highlights.scm` fixes)
- [x] Confirmed the grammar rule removal doesn't change parser behavior: `src/parser.c` regenerates byte-identical
- [ ] `indents.scm`/`folds.scm` fixes verified manually via `tree-sitter query` (no automated test format exists for these query types in this project's tooling or, per a spot-check of tree-sitter-python/rust/go/javascript, mitchellh/tree-sitter-proto, and casey/tree-sitter-just, in comparable grammar repos generally)