### PR TITLE
fix(queries): indent aggregate option values

### DIFF
--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -3,6 +3,7 @@
   (enum_body)
   (oneof)
   (service)
+  (block_lit)
 ] @indent.begin
 
 ; rpc's body is optional (it can end in ";" instead of "{ }"), so anchor on
@@ -12,6 +13,11 @@
   "{" @indent.begin)
 
 "}" @indent.end @indent.branch
+
+; A block_lit may be delimited by angle brackets instead of braces. Anchor on
+; the node so this doesn't fire for the ">" that closes a map<K, V> type.
+(block_lit
+  ">" @indent.end @indent.branch)
 
 [
   (ERROR)


### PR DESCRIPTION
Query-only change — no grammar or parser changes.

`block_lit` was never an `indent.begin`, so a multi-line option value got no indent, even though the bare `"}"` rule already dedented on its closing brace.

This adds the node, and adds its closing angle bracket **anchored to `block_lit`** so the rule does not also fire for the `>` that closes a `map<K, V>` type:

```scm
(block_lit
  ">" @indent.end @indent.branch)
```

### Verification

Checked with `tree-sitter query` against a message containing both a map field and a multi-line aggregate option value:

```proto
message M {
  map<string, int32> m = 1;
  option (foo.bar) = {
    a: 1
    b: <c: 2>
    [type.googleapis.com/foo.Bar]: { d: 3 }
  };
}
```

The map's `>` receives **no** capture; both `block_lit` delimiters are captured as `indent.end`/`indent.branch`.

```
tree-sitter test  →  38/38 parses, 0 failures, 67 highlight assertions
```

---

*Top of a 6-PR stack; based on #31. CI now runs on this PR thanks to #34 at the bottom of the stack.*


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>