### PR TITLE
ci: run CI on query changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - grammar.js
       - src/**
       - test/**
+      - queries/**
       - .github/**
       - bindings/**
       - binding.gyp
@@ -15,6 +16,7 @@ on:
       - grammar.js
       - src/**
       - test/**
+      - queries/**
       - .github/**
       - bindings/**
       - binding.gyp


### PR DESCRIPTION
The workflow's `paths` filter listed `grammar.js`, `src/**`, `test/**`, `.github/**`, `bindings/**`, and `binding.gyp` — but not `queries/**`.

A PR touching only a query file therefore triggered **no workflow at all**, including the `Validate queries` job that runs `ts_query_ls check -f queries/` against exactly those files. That job is the one check that would catch a broken query, and it was the one that couldn't run.

This adds `queries/**` to both the `push` and `pull_request` filters.

### How this surfaced

The top of this stack (#32) is a query-only change. On its first push it reported *no checks whatsoever* — that's what turned this up. With this PR at the bottom of the stack, #32 inherits the fix and gets validated properly.

It's not new to this stack: the previously merged #26 also touched `queries/` under the same gap.

---

*Bottom of a 6-PR stack. Independent of the rest — it only touches the workflow's path filters, so it can merge on its own.*

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
