### PR TITLE
fix(queries): fold aggregate option values, highlight reserved names

### DIFF
--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -6,6 +6,7 @@
   (service)
   (oneof)
   (rpc)
+  (block_lit)
 ] @fold
 
 (import)+ @fold

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -140,6 +140,10 @@
 
 (string) @string
 
+; reserved names are their own node type rather than (string), so they need
+; their own rule - without it they are the only unhighlighted literal.
+(reserved_identifier) @string
+
 (import
   path: (string) @string.special.path)
 

--- a/test/highlight/highlights.proto
+++ b/test/highlight/highlights.proto
@@ -164,3 +164,11 @@ message PunctuationTest {
 //                            ^ number
 //                             ^ punctuation.delimiter
 }
+
+// reserved names are their own node type, not (string)
+message ReservedNameTest {
+  reserved "foo", "bar";
+//^ keyword
+//         ^ string
+//                ^ string
+}


### PR DESCRIPTION
Two query-only gaps, both left over from the query pass in #32. No grammar or parser changes.

### `block_lit` was indentable but not foldable

#32 added `block_lit` as an `indent.begin`, but it was never added to `folds.scm` — so a multi-line aggregate option value indented correctly and then couldn't be folded. Every other brace-delimited body in the grammar is foldable.

Before, on a message containing a multi-line option value, the fold query captured the enclosing `message` and a nested `enum` but nothing for the option body. Now:

```
capture: fold, start: (1, 0), end: (7, 1)   ← message
capture: fold, start: (2, 21), end: (5, 3)  ← block_lit  (new)
capture: fold, start: (6, 2), end: (6, 19)  ← enum
```

### `reserved "foo";` had no highlight at all

Reserved names parse as `reserved_identifier`, which is its own node type rather than `(string)`, so no rule matched them. Only the `reserved` keyword and the `;` were captured — reserved names were the **one literal in the grammar that rendered as plain unstyled text**, while every other string in the file was highlighted.

```scm
(reserved_identifier) @string
```

### Verification

```
tree-sitter test  →  38/38 parses, 0 failures, 70 highlight assertions
```

Three new highlight assertions cover the reserved-name case (67 → 70).

---

*Bottom of a 2-PR stack. Non-breaking and independent — it can merge on its own.*


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>