### PR TITLE
chore: prepare for 0.6.0 tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-proto
-        VERSION "0.5.0"
+        VERSION "0.6.0"
         DESCRIPTION "Parser for proto2 and proto3 files"
         HOMEPAGE_URL "https://github.com/coder3101/tree-sitter-proto"
         LANGUAGES C)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
 name = "tree-sitter-proto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-proto"
 description = "Parser for proto2 and proto3 files"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Mohammad Ashar Khan <ashar786khan@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 LANGUAGE_NAME := tree-sitter-proto
 HOMEPAGE_URL := https://github.com/coder3101/tree-sitter-proto
-VERSION := 0.5.0
+VERSION := 0.6.0
 
 # repository
 SRC_DIR := src

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-proto",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-proto",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-proto",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Parser for proto2 and proto3 files",
   "repository": "github:tree-sitter/tree-sitter-proto",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-proto"
 description = "Parser for proto2 and proto3 files"
-version = "0.5.0"
+version = "0.6.0"
 keywords = ["incremental", "parsing", "tree-sitter", "proto"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/src/parser.c
+++ b/src/parser.c
@@ -11219,7 +11219,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_proto(void) {
     .max_reserved_word_set_size = 0,
     .metadata = {
       .major_version = 0,
-      .minor_version = 5,
+      .minor_version = 6,
       .patch_version = 0,
     },
   };

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -14,7 +14,7 @@
     }
   ],
   "metadata": {
-    "version": "0.5.0",
+    "version": "0.6.0",
     "license": "MIT",
     "description": "Protobuf grammar for tree-sitter",
     "authors": [


### PR DESCRIPTION
Bumps 0.5.0 to 0.6.0 across the nine files #27 touched, including the `.minor_version` in `src/parser.c`. `tree-sitter generate` produces no additional churn against this diff.

Two breaking CST changes since 0.5.0 justify the minor bump:

- `oneof_field` now consumes its terminating `;` (#37), so the spurious `(empty_statement)` sibling after every oneof field is gone.
- `syntax` takes any string literal (#30), so `(syntax)` gains a `(string)` child under a `version` field and the anonymous `"proto3"` / `"proto2"` nodes no longer exist.

Rest of the range: text format in aggregate option values (#31), fully-qualified types in `extend` (#39), option-name extensions / group options / extension range options (#29), query fixes (#32, #36), and the tree-sitter-cli bump to 0.26.13 (#28).

No `CHANGELOG.md` — the changes go in the release notes instead. Worth knowing for that: the reusable workflow runs `gh release create ... -n`, not `--generate-notes`, and this repo passes no `release-body`, so the release body will be only the tarball note until someone edits it (`gh release edit 0.6.0 --notes-file ...`).

Once this lands I'll tag the squashed commit on `main` as `0.6.0` (lightweight, no `v` prefix, matching 0.4.0 and 0.5.0) to fire the release workflow — happy to leave the tag to you instead, just say.
